### PR TITLE
Fix: nefunkční stahování dat od 5. 5. 2026

### DIFF
--- a/egd_api.py
+++ b/egd_api.py
@@ -176,10 +176,11 @@ class EGDAPI:
         unique_data = []
         unique_timestamps = set()
         page_number = 1 # Start with the first page
+        record_start = 1
         while True:
-            # Update the page number in the parameters
-            params_data["pageStart"] = str(page_number)
-            self.debug_print(f"Executing Page number: {page_number}")
+            # Update the page start record index in the parameters
+            params_data["pageStart"] = str(record_start)
+            self.debug_print(f"Executing Page number: {page_number} (record start: {record_start})")
             # Make the GET request to fetch the data
             response_data = requests.get(self.url_data, headers=headers_data, params=params_data)
             # Check if the request was successful
@@ -188,15 +189,17 @@ class EGDAPI:
                 data = response_data.json()
                 if not data:
                     break
-                if isinstance(data, list) and len(data) > 0:
+                if isinstance(data, dict):
+                    first_record = data
+                elif isinstance(data, list) and len(data) > 0:
                     first_record = data[0]
-                    if 'total' in first_record:
-                        total = first_record['total']
-                    else:
-                        self.debug_print(f"Error: 'total' field not found in the response.", "ERROR")
-                        break
                 else:
                     self.debug_print(f"Error: Unexpected response structure. {data}. Maybe the data are not ready yet, try later today after 13:00", "ERROR")
+                    break
+                if 'total' in first_record:
+                    total = first_record['total']
+                else:
+                    self.debug_print(f"Error: 'total' field not found in the response.", "ERROR")
                     break 
                 self.debug_print(f"Iteration: {page_number} Total records: {total}")               
                 # Check if an entry with the same ean/eic, profile, units, and total already exists
@@ -210,8 +213,9 @@ class EGDAPI:
                     # Add the new entry to all_data
                     self.debug_print(f"New data entry found. Adding to the list.","INFO")
                     all_data.append(first_record)
-                if total < 3000:  # If the returned data is less than pageSize, we've reached the last page
+                if len(first_record.get('data', [])) < 3000:  # If the returned data is less than pageSize, we've reached the last page
                     break                
+                record_start += 3000
                 page_number += 1
             else:
                 self.debug_print(f"Failed to get data: {response_data.status_code} - {response_data.text}", "ERROR")
@@ -265,10 +269,12 @@ class EGDAPI:
             local_tz = pytz.timezone('Europe/Prague')
 
             for item in data[0]['data']:
-                if item['status'] == 'IU012':
+                if item['status'] in ['IU012', 'W', 'IU013', 'IU015', 'IU016']:
                     # Convert the timestamp to a datetime object in UTC
-                    utc_time = dt.strptime(item['timestamp'], "%Y-%m-%dT%H:%M:%S.%fZ")
-                    utc_time = utc.localize(utc_time)
+                    from dateutil.parser import isoparse
+                    utc_time = isoparse(item['timestamp'])
+                    if utc_time.tzinfo is None:
+                        utc_time = utc.localize(utc_time)
                     # Convert the UTC time to local time
                     local_time = utc_time.astimezone(local_tz)
                     # Extract the date and hour part in local time
@@ -306,7 +312,7 @@ class EGDAPI:
                 aggregated_data['total'] = round(total, 2)
 
             for key in aggregated_data:
-                aggregated_data[key] = round(aggregated_data[key], 2)
+                aggregated_data[key] = round(aggregated_data[key], 4)
 
             aggregated_data_json = json.dumps(aggregated_data)
         except Exception as e:


### PR DESCRIPTION
Používám api v branchi `test` k stahování dat do vlastního systému (Grafana). To už je 2 měsíce nefunkční. Nechal jsem to AI opravit. Následně při importu dat za chybějící období jsem zjistil nefunkčnost stahování dat za více než 30 dní. Nechal jsem to opravit také a import chybějících dat se povedl. Níže přidávám výstup z AI pro informaci. Našel jsem i aktuální [dokumentaci k API](https://www.egd.cz/sites/default/files/2026-05/uzivatelsky_navod_openapi_abc.pdf) a AI potvrdila, že provedené změny jsou v souladu.

### Stahování dat
```
Problém byl způsoben třemi změnami v chování API EG.D CZ (pravděpodobně k nim došlo při nějaké aktualizaci na jejich straně):

Změna formátu odpovědi API: API dříve vracelo seznam (list) obsahující slovník s daty, ale nyní vrací slovník (dict) přímo. Původní kontrola isinstance(data, list) tak selhala a script skončil chybou s prázdným výsledkem.

Oprava: V souboru 

egd_api.py
 jsem upravil zpracování tak, aby podporovalo jak nový formát (slovník), tak případně i starý (seznam).


Změna statusu měření: Původní script zpracovával pouze data se statusem IU012 (což odpovídá platnému měření pro typy A a B). Vaše měření ale vrací status W (který EG.D používá pro platná data u měření typu C).

Oprava: V metodě sum_data v 

egd_api.py
 jsem rozšířil seznam povolených stavů. Nyní script akceptuje jak IU012 a W (platná měření), tak i IU013 (odhadnutá hodnota) nebo IU015/IU016 (ručně zadaná/uvolněná data), aby nedocházelo k výpadkům v grafech.


Formát časových značek (Timestamps): API přestalo v časových značkách posílat milisekundy (posílá např. 2026-06-19T22:15:00Z místo 2026-06-19T22:15:00.000Z), což způsobovalo pád původní funkce strptime.

Oprava: Nahradil jsem pevný formát strptime robustní funkcí isoparse z knihovny dateutil.parser, která si poradí s oběma variantami časových razítek.
```

### Stahování dat za více jak 30 dnů
```
1. Proč to padalo (hangovalo) při více než 30 dnech?
Problém byl ve stránkování rozhraní EG.D:

Limit pro jeden dotaz je 3000 záznamů (což odpovídá cca 31 dnům čtvrthodinových měření). Pokud požadujete více dat, je třeba jít na další stránku pomocí parametru pageStart.
Parametr pageStart v EG.D API ale neoznačuje číslo stránky (1, 2, 3...), nýbrž pořadové číslo záznamu (offset), kterým má API začít.
V původním kódu se ale pageStart zvyšoval o 1 (page_number += 1). Když jste tedy požádal o více než 30 dní, script stáhl prvních 3000 záznamů, a v dalším kroku požádal o záznamy začínající od indexu 2 (místo 3001). Znovu tak dostal 3000 záznamů, pak se dotázal od indexu 3 atd. To vedlo k nekonečné smyčce (zacyklení).
Oprava: V souboru 

egd_api.py
 jsem upravil logiku stránkování tak, aby se index správně posouval o velikost stránky (tedy o 3000 záznamů). Test na stažení 60 dnů nyní doběhne úspěšně za zhruba 2 sekundy.
```